### PR TITLE
fix(auth): support encrypted Teams login caches

### DIFF
--- a/internal/teams/auth/msal.go
+++ b/internal/teams/auth/msal.go
@@ -1,8 +1,14 @@
 package auth
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -20,11 +26,38 @@ type msalTokenEntry struct {
 	Target    string `json:"target"`
 }
 
+// extractedMSALEncryptionCookieKey is added to the copied storage payload by
+// the webview script. MSAL keeps this session key in a cookie, not localStorage.
+const extractedMSALEncryptionCookieKey = "__mautrix_teams_msal_cache_encryption"
+
 func ExtractTokensFromMSALLocalStorage(raw string, clientID string) (*AuthState, error) {
 	storage, err := parseStorage(raw)
 	if err != nil {
 		return nil, err
 	}
+	clientID = resolveMSALClientID(storage, clientID)
+
+	state := &AuthState{}
+	var extractionErrors []error
+	if msalState, msalErr := extractMSALTokens(storage, clientID); msalErr == nil {
+		mergeAuthState(state, msalState)
+	} else {
+		extractionErrors = append(extractionErrors, msalErr)
+	}
+	if teamsState, teamsErr := extractTeamsAuthTokens(storage); teamsErr == nil {
+		mergeAuthState(state, teamsState)
+	} else {
+		extractionErrors = append(extractionErrors, teamsErr)
+	}
+
+	if state.RefreshToken == "" && state.AccessToken == "" && state.SkypeToken == "" {
+		return nil, fmt.Errorf("no usable Teams authentication tokens found: %w", errors.Join(extractionErrors...))
+	}
+	return state, nil
+}
+
+func extractMSALTokens(storage map[string]string, clientID string) (*AuthState, error) {
+	cacheKey := extractMSALEncryptionKey(storage)
 	keysEntry, err := findMSALKeys(storage, clientID)
 	if err != nil {
 		return nil, err
@@ -38,14 +71,9 @@ func ExtractTokensFromMSALLocalStorage(raw string, clientID string) (*AuthState,
 		return nil, errors.New("no refresh token keys in msal token keys")
 	}
 
-	refreshEntry, ok := storage[keys.RefreshToken[0]]
-	if !ok {
-		return nil, errors.New("refresh token entry not found in localStorage")
-	}
-
-	var refresh msalTokenEntry
-	if err := json.Unmarshal([]byte(refreshEntry), &refresh); err != nil {
-		return nil, err
+	refresh, err := readMSALEntry(storage, keys.RefreshToken[0], clientID, cacheKey)
+	if err != nil {
+		return nil, fmt.Errorf("refresh token entry: %w", err)
 	}
 	if refresh.Secret == "" {
 		return nil, errors.New("refresh token secret missing")
@@ -61,14 +89,14 @@ func ExtractTokensFromMSALLocalStorage(raw string, clientID string) (*AuthState,
 	}
 
 	if len(keys.AccessToken) > 0 {
-		accessToken, expiresAt := selectMBIAccessToken(storage, keys.AccessToken)
+		accessToken, expiresAt := selectMBIAccessToken(storage, keys.AccessToken, clientID, cacheKey)
 		if accessToken != "" {
 			state.AccessToken = accessToken
 			if expiresAt != 0 {
 				state.ExpiresAtUnix = expiresAt
 			}
 		}
-		graphAccessToken, graphExpiresAt := selectGraphAccessToken(storage, keys.AccessToken)
+		graphAccessToken, graphExpiresAt := selectGraphAccessToken(storage, keys.AccessToken, clientID, cacheKey)
 		if graphAccessToken != "" {
 			state.GraphAccessToken = graphAccessToken
 			if graphExpiresAt != 0 {
@@ -78,11 +106,8 @@ func ExtractTokensFromMSALLocalStorage(raw string, clientID string) (*AuthState,
 	}
 
 	if len(keys.IDToken) > 0 {
-		if idEntry, ok := storage[keys.IDToken[0]]; ok {
-			var idToken msalTokenEntry
-			if err := json.Unmarshal([]byte(idEntry), &idToken); err == nil {
-				state.IDToken = idToken.Secret
-			}
+		if idToken, err := readMSALEntry(storage, keys.IDToken[0], clientID, cacheKey); err == nil {
+			state.IDToken = idToken.Secret
 		}
 	}
 
@@ -91,16 +116,12 @@ func ExtractTokensFromMSALLocalStorage(raw string, clientID string) (*AuthState,
 
 const mbiAccessTokenMarker = "service::api.fl.spaces.skype.com::mbi_ssl"
 
-func selectMBIAccessToken(storage map[string]string, keys []string) (string, int64) {
+func selectMBIAccessToken(storage map[string]string, keys []string, clientID string, cacheKey *msalCacheEncryptionKey) (string, int64) {
 	var bestToken string
 	var bestExpiry int64
 	for _, key := range keys {
-		raw, ok := storage[key]
-		if !ok || raw == "" {
-			continue
-		}
-		var entry msalTokenEntry
-		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		entry, err := readMSALEntry(storage, key, clientID, cacheKey)
+		if err != nil {
 			continue
 		}
 		if entry.Secret == "" || !matchesMBITarget(entry.Target) {
@@ -123,16 +144,12 @@ func matchesMBITarget(target string) bool {
 	return strings.Contains(lower, mbiAccessTokenMarker)
 }
 
-func selectGraphAccessToken(storage map[string]string, keys []string) (string, int64) {
+func selectGraphAccessToken(storage map[string]string, keys []string, clientID string, cacheKey *msalCacheEncryptionKey) (string, int64) {
 	var bestToken string
 	var bestExpiry int64
 	for _, key := range keys {
-		raw, ok := storage[key]
-		if !ok || raw == "" {
-			continue
-		}
-		var entry msalTokenEntry
-		if err := json.Unmarshal([]byte(raw), &entry); err != nil {
+		entry, err := readMSALEntry(storage, key, clientID, cacheKey)
+		if err != nil {
 			continue
 		}
 		if entry.Secret == "" || !matchesGraphTarget(entry.Target) {
@@ -221,4 +238,153 @@ func parseMSALExpires(value string) (int64, bool) {
 		return parsed.UTC().Unix(), true
 	}
 	return 0, false
+}
+
+type msalCacheEncryptionKey struct {
+	ID  string
+	Key []byte
+}
+
+type msalEncryptedEnvelope struct {
+	ID    string `json:"id"`
+	Nonce string `json:"nonce"`
+	Data  string `json:"data"`
+}
+
+func readMSALEntry(storage map[string]string, storageKey, clientID string, cacheKey *msalCacheEncryptionKey) (msalTokenEntry, error) {
+	raw, ok := storage[storageKey]
+	if !ok {
+		return msalTokenEntry{}, errors.New("not found in localStorage")
+	}
+	plain, err := decryptMSALEntryValue(cacheKey, storageKey, clientID, raw)
+	if err != nil {
+		return msalTokenEntry{}, err
+	}
+	var entry msalTokenEntry
+	if err := json.Unmarshal([]byte(plain), &entry); err != nil {
+		return msalTokenEntry{}, err
+	}
+	return entry, nil
+}
+
+// decryptMSALEntryValue mirrors @azure/msal-browser's encrypted localStorage
+// format: HKDF-SHA256 derives an AES-256-GCM key per entry, with a zero IV.
+func decryptMSALEntryValue(cacheKey *msalCacheEncryptionKey, storageKey, clientID, rawValue string) (string, error) {
+	var envelope msalEncryptedEnvelope
+	if err := json.Unmarshal([]byte(rawValue), &envelope); err != nil {
+		return rawValue, nil
+	}
+	if envelope.Data == "" || envelope.Nonce == "" {
+		return rawValue, nil
+	}
+	if cacheKey == nil || len(cacheKey.Key) == 0 {
+		return "", errors.New("entry is encrypted but the MSAL encryption cookie was not captured")
+	}
+	if envelope.ID != "" && cacheKey.ID != "" && envelope.ID != cacheKey.ID {
+		return "", errors.New("entry was encrypted with a different MSAL session key")
+	}
+	nonce, err := decodeAuthBase64(envelope.Nonce)
+	if err != nil {
+		return "", fmt.Errorf("decode nonce: %w", err)
+	}
+	ciphertext, err := decodeAuthBase64(envelope.Data)
+	if err != nil {
+		return "", fmt.Errorf("decode data: %w", err)
+	}
+	context := ""
+	if clientID != "" && strings.Contains(storageKey, clientID) {
+		context = clientID
+	}
+	derivedKey, err := hkdf.Key(sha256.New, cacheKey.Key, nonce, context, 32)
+	if err != nil {
+		return "", fmt.Errorf("derive key: %w", err)
+	}
+	block, err := aes.NewCipher(derivedKey)
+	if err != nil {
+		return "", fmt.Errorf("create AES cipher: %w", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("create AES-GCM cipher: %w", err)
+	}
+	plaintext, err := gcm.Open(nil, make([]byte, gcm.NonceSize()), ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt AES-GCM entry: %w", err)
+	}
+	return string(plaintext), nil
+}
+
+func extractMSALEncryptionKey(storage map[string]string) *msalCacheEncryptionKey {
+	raw := strings.TrimSpace(storage[extractedMSALEncryptionCookieKey])
+	if raw == "" {
+		return nil
+	}
+	var cookie struct {
+		ID  string `json:"id"`
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal([]byte(raw), &cookie); err != nil || cookie.Key == "" {
+		return nil
+	}
+	key, err := decodeAuthBase64(cookie.Key)
+	if err != nil {
+		return nil
+	}
+	return &msalCacheEncryptionKey{ID: cookie.ID, Key: key}
+}
+
+func resolveMSALClientID(storage map[string]string, clientID string) string {
+	if strings.TrimSpace(clientID) != "" {
+		return clientID
+	}
+	const marker = ".token.keys."
+	for key := range storage {
+		if i := strings.Index(key, marker); i != -1 {
+			return key[i+len(marker):]
+		}
+	}
+	return ""
+}
+
+func decodeAuthBase64(value string) ([]byte, error) {
+	value = strings.TrimSpace(value)
+	for _, encoding := range []*base64.Encoding{
+		base64.RawURLEncoding,
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+	} {
+		decoded, err := encoding.DecodeString(value)
+		if err == nil {
+			return decoded, nil
+		}
+	}
+	return nil, errors.New("invalid base64")
+}
+
+func mergeAuthState(destination, source *AuthState) {
+	if destination == nil || source == nil {
+		return
+	}
+	if destination.AccessToken == "" {
+		destination.AccessToken = source.AccessToken
+		destination.ExpiresAtUnix = source.ExpiresAtUnix
+	}
+	if destination.RefreshToken == "" {
+		destination.RefreshToken = source.RefreshToken
+	}
+	if destination.IDToken == "" {
+		destination.IDToken = source.IDToken
+	}
+	if destination.SkypeToken == "" {
+		destination.SkypeToken = source.SkypeToken
+		destination.SkypeTokenExpiresAt = source.SkypeTokenExpiresAt
+	}
+	if destination.GraphAccessToken == "" {
+		destination.GraphAccessToken = source.GraphAccessToken
+		destination.GraphExpiresAt = source.GraphExpiresAt
+	}
+	if destination.TeamsUserID == "" {
+		destination.TeamsUserID = source.TeamsUserID
+	}
 }

--- a/internal/teams/auth/msal_test.go
+++ b/internal/teams/auth/msal_test.go
@@ -1,6 +1,15 @@
 package auth
 
-import "testing"
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
 
 func TestSelectMBIAccessToken(t *testing.T) {
 	storage := map[string]string{
@@ -10,7 +19,7 @@ func TestSelectMBIAccessToken(t *testing.T) {
 	}
 	keys := []string{"access1", "access2", "access3"}
 
-	token, expiry := selectMBIAccessToken(storage, keys)
+	token, expiry := selectMBIAccessToken(storage, keys, "", nil)
 	if token != "token-mbi-2" {
 		t.Fatalf("unexpected token: %s", token)
 	}
@@ -27,7 +36,7 @@ func TestSelectGraphAccessToken(t *testing.T) {
 	}
 	keys := []string{"access1", "access2", "access3"}
 
-	token, expiry := selectGraphAccessToken(storage, keys)
+	token, expiry := selectGraphAccessToken(storage, keys, "", nil)
 	if token != "token-graph-2" {
 		t.Fatalf("unexpected token: %s", token)
 	}
@@ -42,7 +51,7 @@ func TestSelectGraphAccessTokenMissing(t *testing.T) {
 	}
 	keys := []string{"access1"}
 
-	token, expiry := selectGraphAccessToken(storage, keys)
+	token, expiry := selectGraphAccessToken(storage, keys, "", nil)
 	if token != "" || expiry != 0 {
 		t.Fatalf("expected no token, got %q with expiry %d", token, expiry)
 	}
@@ -54,8 +63,183 @@ func TestSelectMBIAccessTokenMissing(t *testing.T) {
 	}
 	keys := []string{"access1"}
 
-	token, expiry := selectMBIAccessToken(storage, keys)
+	token, expiry := selectMBIAccessToken(storage, keys, "", nil)
 	if token != "" || expiry != 0 {
 		t.Fatalf("expected no token, got %q with expiry %d", token, expiry)
 	}
+}
+
+func TestExtractTokensFromEncryptedMSALStorage(t *testing.T) {
+	t.Parallel()
+	baseKey := randomBytes(t, 32)
+	const (
+		clientID = "4b3e8f46-56d3-427f-b1e2-d239b2ea6bca"
+		keyID    = "4d36b33d-5f4f-4f28-970f-7f28a2b7262e"
+	)
+	refreshKey := "msal.2|home|env|refreshtoken|" + clientID + "|||"
+	mbiKey := "msal.2|home|env|accesstoken|" + clientID + "||service::api.fl.spaces.skype.com::MBI_SSL|"
+	graphKey := "msal.2|home|env|accesstoken|" + clientID + "||https://graph.microsoft.com/Files.ReadWrite|"
+	idKey := "msal.2|home|env|idtoken|" + clientID + "|||"
+	storage := map[string]string{
+		"msal.token.keys." + clientID: `{"refreshToken":["` + refreshKey + `"],"idToken":["` + idKey + `"],"accessToken":["` + mbiKey + `","` + graphKey + `"]}`,
+		extractedMSALEncryptionCookieKey: mustJSON(t, map[string]string{
+			"id":  keyID,
+			"key": base64.RawURLEncoding.EncodeToString(baseKey),
+		}),
+		refreshKey: sealMSALEntry(t, baseKey, keyID, clientID, `{"secret":"refresh-token","expiresOn":"1700000000"}`),
+		mbiKey:     sealMSALEntry(t, baseKey, keyID, clientID, `{"secret":"mbi-token","expiresOn":"1700000100","target":"service::api.fl.spaces.skype.com::MBI_SSL"}`),
+		graphKey:   sealMSALEntry(t, baseKey, keyID, clientID, `{"secret":"graph-token","expiresOn":"1700000200","target":"https://graph.microsoft.com/Files.ReadWrite"}`),
+		idKey:      sealMSALEntry(t, baseKey, keyID, clientID, `{"secret":"id-token"}`),
+	}
+
+	state, err := ExtractTokensFromMSALLocalStorage(mustJSON(t, storage), clientID)
+	if err != nil {
+		t.Fatalf("extract encrypted MSAL storage: %v", err)
+	}
+	if state.RefreshToken != "refresh-token" {
+		t.Fatalf("unexpected refresh token: %q", state.RefreshToken)
+	}
+	if state.AccessToken != "mbi-token" || state.ExpiresAtUnix != 1700000100 {
+		t.Fatalf("unexpected MBI token state: token=%q expiry=%d", state.AccessToken, state.ExpiresAtUnix)
+	}
+	if state.GraphAccessToken != "graph-token" || state.GraphExpiresAt != 1700000200 {
+		t.Fatalf("unexpected Graph token state: token=%q expiry=%d", state.GraphAccessToken, state.GraphExpiresAt)
+	}
+	if state.IDToken != "id-token" {
+		t.Fatalf("unexpected ID token: %q", state.IDToken)
+	}
+}
+
+func TestExtractTokensFromEncryptedMSALStorageRejectsWrongSessionKey(t *testing.T) {
+	t.Parallel()
+	baseKey := randomBytes(t, 32)
+	const clientID = "client-id"
+	refreshKey := "msal.2|home|env|refreshtoken|" + clientID + "|||"
+	storage := map[string]string{
+		"msal.token.keys." + clientID: `{"refreshToken":["` + refreshKey + `"]}`,
+		extractedMSALEncryptionCookieKey: mustJSON(t, map[string]string{
+			"id":  "new-session",
+			"key": base64.RawURLEncoding.EncodeToString(baseKey),
+		}),
+		refreshKey: sealMSALEntry(t, baseKey, "old-session", clientID, `{"secret":"refresh-token"}`),
+	}
+
+	if _, err := ExtractTokensFromMSALLocalStorage(mustJSON(t, storage), clientID); err == nil {
+		t.Fatal("expected extraction to reject an entry from a different MSAL session")
+	}
+}
+
+func TestExtractTokensFromTeamsAuthCache(t *testing.T) {
+	t.Parallel()
+	baseKey := randomBytes(t, 32)
+	storage := map[string]string{
+		"tmp.auth.v1.GLOBAL.ExportedEncryptionKey.ExportedEncryptionKey": mustJSON(t, map[string]any{
+			"item": map[string]string{"exportedKey": base64.StdEncoding.EncodeToString(baseKey)},
+		}),
+		"tmp.auth.v1.GLOBAL.PrimaryUserId.PrimaryUserId": mustJSON(t, map[string]any{
+			"item": "live-user",
+		}),
+		"tmp.auth.v1.live-user.Token.HTTPS://API.FL.SPACES.SKYPE.COM": teamsAuthCacheValue(t, baseKey, "mbi-token", map[string]any{
+			"expiration": int64(1_700_000_100_000),
+		}),
+		"tmp.auth.v1.live-user.Token.HTTPS://GRAPH.MICROSOFT.COM": teamsAuthCacheValue(t, baseKey, "graph-token", map[string]any{
+			"expiration": int64(1_700_000_200_000),
+		}),
+		"tmp.auth.v1.live-user.Discover.SKYPE-TOKEN": teamsAuthCacheValue(t, baseKey, "skype-token", map[string]any{
+			"expiration":  int64(1_700_000_300_000),
+			"userDetails": map[string]string{"id": "live:tester"},
+		}),
+		"tmp.auth.v1.other-user.Discover.SKYPE-TOKEN": teamsAuthCacheValue(t, baseKey, "wrong-user-token", map[string]any{
+			"expiration":  int64(1_800_000_300_000),
+			"userDetails": map[string]string{"id": "live:wrong-user"},
+		}),
+	}
+
+	state, err := ExtractTokensFromMSALLocalStorage(mustJSON(t, storage), "")
+	if err != nil {
+		t.Fatalf("extract Teams auth cache: %v", err)
+	}
+	if state.AccessToken != "mbi-token" || state.ExpiresAtUnix != 1700000100 {
+		t.Fatalf("unexpected MBI token state: token=%q expiry=%d", state.AccessToken, state.ExpiresAtUnix)
+	}
+	if state.GraphAccessToken != "graph-token" || state.GraphExpiresAt != 1700000200 {
+		t.Fatalf("unexpected Graph token state: token=%q expiry=%d", state.GraphAccessToken, state.GraphExpiresAt)
+	}
+	if state.SkypeToken != "skype-token" || state.SkypeTokenExpiresAt != 1700000300 {
+		t.Fatalf("unexpected Skype token state: token=%q expiry=%d", state.SkypeToken, state.SkypeTokenExpiresAt)
+	}
+	if state.TeamsUserID != "live:tester" {
+		t.Fatalf("unexpected Teams user ID: %q", state.TeamsUserID)
+	}
+}
+
+func sealMSALEntry(t *testing.T, baseKey []byte, keyID, context, plaintext string) string {
+	t.Helper()
+	nonce := randomBytes(t, 16)
+	key, err := hkdf.Key(sha256.New, baseKey, nonce, context, 32)
+	if err != nil {
+		t.Fatalf("derive test key: %v", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("create test cipher: %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("create test GCM: %v", err)
+	}
+	return mustJSON(t, map[string]any{
+		"id":            keyID,
+		"nonce":         base64.RawURLEncoding.EncodeToString(nonce),
+		"data":          base64.RawURLEncoding.EncodeToString(gcm.Seal(nil, make([]byte, gcm.NonceSize()), []byte(plaintext), nil)),
+		"lastUpdatedAt": "1700000000000",
+	})
+}
+
+func teamsAuthCacheValue(t *testing.T, baseKey []byte, plaintext string, extra map[string]any) string {
+	t.Helper()
+	iv := randomBytes(t, aes.BlockSize)
+	block, err := aes.NewCipher(baseKey)
+	if err != nil {
+		t.Fatalf("create test cipher: %v", err)
+	}
+	padded := padPKCS7([]byte(plaintext), block.BlockSize())
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+	item := map[string]any{
+		"encryptedToken": base64.StdEncoding.EncodeToString(ciphertext),
+		"iv":             base64.StdEncoding.EncodeToString(iv),
+	}
+	for key, value := range extra {
+		item[key] = value
+	}
+	return mustJSON(t, map[string]any{"item": item})
+}
+
+func padPKCS7(plaintext []byte, blockSize int) []byte {
+	padding := blockSize - len(plaintext)%blockSize
+	out := make([]byte, len(plaintext)+padding)
+	copy(out, plaintext)
+	for i := len(plaintext); i < len(out); i++ {
+		out[i] = byte(padding)
+	}
+	return out
+}
+
+func randomBytes(t *testing.T, size int) []byte {
+	t.Helper()
+	out := make([]byte, size)
+	if _, err := rand.Read(out); err != nil {
+		t.Fatalf("read random bytes: %v", err)
+	}
+	return out
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return string(encoded)
 }

--- a/internal/teams/auth/teams_cache.go
+++ b/internal/teams/auth/teams_cache.go
@@ -1,0 +1,231 @@
+package auth
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const exportedEncryptionKeyStorageSuffix = ".ExportedEncryptionKey.ExportedEncryptionKey"
+
+// teamsAuthCacheItem is the separate cache format used by Teams' auth layer.
+// Unlike MSAL's AES-GCM envelopes, these tokens use AES-256-CBC with the raw
+// key and per-token IV stored in adjacent tmp.auth.v1 localStorage entries.
+type teamsAuthCacheItem struct {
+	Token           string          `json:"token"`
+	SkypeToken      string          `json:"skypeToken"`
+	EncryptedToken  string          `json:"encryptedToken"`
+	IV              string          `json:"iv"`
+	Expiration      json.RawMessage `json:"expiration"`
+	TokenExpiration json.RawMessage `json:"tokenExpiration"`
+	ExpiresOn       json.RawMessage `json:"expiresOn"`
+	SkypeID         string          `json:"skypeid"`
+	UserDetails     struct {
+		ID string `json:"id"`
+	} `json:"userDetails"`
+}
+
+func extractTeamsAuthTokens(storage map[string]string) (*AuthState, error) {
+	baseKey := extractTeamsAuthEncryptionKey(storage)
+	primaryUser := extractPrimaryTeamsAuthUser(storage)
+	state := &AuthState{}
+	var foundCacheEntry bool
+	var decryptErr error
+	for storageKey, raw := range storage {
+		lowerKey := strings.ToLower(storageKey)
+		isSkypeToken := strings.HasSuffix(lowerKey, ".discover.skype-token")
+		isToken := strings.Contains(lowerKey, ".token.")
+		if !isSkypeToken && !isToken {
+			continue
+		}
+		if cacheUser := teamsAuthCacheUser(storageKey); primaryUser != "" && cacheUser != "" && cacheUser != primaryUser {
+			continue
+		}
+		var wrapper struct {
+			Item teamsAuthCacheItem `json:"item"`
+		}
+		if err := json.Unmarshal([]byte(raw), &wrapper); err != nil {
+			continue
+		}
+		item := wrapper.Item
+		if item.Token == "" && item.SkypeToken == "" && item.EncryptedToken == "" {
+			continue
+		}
+		foundCacheEntry = true
+		decrypted := item.Token
+		if isSkypeToken {
+			decrypted = item.SkypeToken
+		}
+		if decrypted == "" && item.EncryptedToken != "" && item.IV != "" && len(baseKey) > 0 {
+			var currentDecryptErr error
+			decrypted, currentDecryptErr = decryptTeamsAuthToken(baseKey, item.EncryptedToken, item.IV)
+			if currentDecryptErr != nil {
+				decryptErr = currentDecryptErr
+			}
+		}
+		if decrypted == "" {
+			continue
+		}
+		expiresAt := parseTeamsAuthExpiry(item.TokenExpiration, item.Expiration, item.ExpiresOn)
+		switch {
+		case isSkypeToken:
+			if shouldReplaceCachedToken(state.SkypeToken, state.SkypeTokenExpiresAt, expiresAt) {
+				state.SkypeToken = decrypted
+				state.SkypeTokenExpiresAt = expiresAt
+				state.TeamsUserID = firstNonEmpty(item.UserDetails.ID, item.SkypeID)
+			}
+		case strings.Contains(lowerKey, "graph.microsoft.com"):
+			if shouldReplaceCachedToken(state.GraphAccessToken, state.GraphExpiresAt, expiresAt) {
+				state.GraphAccessToken = decrypted
+				state.GraphExpiresAt = expiresAt
+			}
+		case strings.Contains(lowerKey, "spaces.skype.com"):
+			if shouldReplaceCachedToken(state.AccessToken, state.ExpiresAtUnix, expiresAt) {
+				state.AccessToken = decrypted
+				state.ExpiresAtUnix = expiresAt
+			}
+		}
+	}
+	if state.SkypeToken == "" && state.AccessToken == "" && state.GraphAccessToken == "" {
+		if foundCacheEntry && len(baseKey) == 0 {
+			return nil, errors.New("teams auth entries are encrypted but no exported encryption key was found")
+		}
+		if foundCacheEntry && decryptErr != nil {
+			return nil, fmt.Errorf("failed to decrypt Teams auth cache entries: %w", decryptErr)
+		}
+		return nil, errors.New("teams auth cache entries not found")
+	}
+	return state, nil
+}
+
+func extractTeamsAuthEncryptionKey(storage map[string]string) []byte {
+	for storageKey, raw := range storage {
+		if !strings.HasSuffix(strings.ToLower(storageKey), strings.ToLower(exportedEncryptionKeyStorageSuffix)) {
+			continue
+		}
+		var wrapper struct {
+			Item struct {
+				ExportedKey string `json:"exportedKey"`
+			} `json:"item"`
+		}
+		if err := json.Unmarshal([]byte(raw), &wrapper); err != nil {
+			continue
+		}
+		key, err := decodeAuthBase64(wrapper.Item.ExportedKey)
+		if err == nil {
+			return key
+		}
+	}
+	return nil
+}
+
+func extractPrimaryTeamsAuthUser(storage map[string]string) string {
+	for storageKey, raw := range storage {
+		if !strings.HasSuffix(strings.ToLower(storageKey), ".primaryuserid.primaryuserid") {
+			continue
+		}
+		var wrapper struct {
+			Item string `json:"item"`
+		}
+		if err := json.Unmarshal([]byte(raw), &wrapper); err == nil {
+			return strings.TrimSpace(wrapper.Item)
+		}
+	}
+	return ""
+}
+
+func teamsAuthCacheUser(storageKey string) string {
+	const prefix = "tmp.auth.v1."
+	if !strings.HasPrefix(strings.ToLower(storageKey), prefix) {
+		return ""
+	}
+	remainder := storageKey[len(prefix):]
+	if separator := strings.IndexByte(remainder, '.'); separator >= 0 {
+		return remainder[:separator]
+	}
+	return ""
+}
+
+func shouldReplaceCachedToken(current string, currentExpiry, candidateExpiry int64) bool {
+	return current == "" || candidateExpiry > currentExpiry
+}
+
+func decryptTeamsAuthToken(baseKey []byte, encryptedToken, encodedIV string) (string, error) {
+	ciphertext, err := decodeAuthBase64(encryptedToken)
+	if err != nil {
+		return "", fmt.Errorf("decode encrypted token: %w", err)
+	}
+	iv, err := decodeAuthBase64(encodedIV)
+	if err != nil {
+		return "", fmt.Errorf("decode IV: %w", err)
+	}
+	block, err := aes.NewCipher(baseKey)
+	if err != nil {
+		return "", fmt.Errorf("create AES cipher: %w", err)
+	}
+	if len(iv) != block.BlockSize() {
+		return "", errors.New("invalid AES-CBC IV size")
+	}
+	if len(ciphertext) == 0 || len(ciphertext)%block.BlockSize() != 0 {
+		return "", errors.New("invalid AES-CBC ciphertext size")
+	}
+	plaintext := make([]byte, len(ciphertext))
+	cipher.NewCBCDecrypter(block, iv).CryptBlocks(plaintext, ciphertext)
+	plaintext, err = unpadPKCS7(plaintext, block.BlockSize())
+	if err != nil {
+		return "", err
+	}
+	if !utf8.Valid(plaintext) || strings.TrimSpace(string(plaintext)) == "" {
+		return "", errors.New("decrypted Teams auth token is not valid UTF-8 text")
+	}
+	return string(plaintext), nil
+}
+
+func unpadPKCS7(plaintext []byte, blockSize int) ([]byte, error) {
+	if len(plaintext) == 0 || len(plaintext)%blockSize != 0 {
+		return nil, errors.New("invalid PKCS#7 plaintext size")
+	}
+	padding := int(plaintext[len(plaintext)-1])
+	if padding == 0 || padding > blockSize || padding > len(plaintext) {
+		return nil, errors.New("invalid PKCS#7 padding")
+	}
+	for _, value := range plaintext[len(plaintext)-padding:] {
+		if int(value) != padding {
+			return nil, errors.New("invalid PKCS#7 padding")
+		}
+	}
+	return plaintext[:len(plaintext)-padding], nil
+}
+
+func parseTeamsAuthExpiry(values ...json.RawMessage) int64 {
+	for _, raw := range values {
+		trimmed := strings.Trim(strings.TrimSpace(string(raw)), `"`)
+		if trimmed == "" || trimmed == "null" {
+			continue
+		}
+		if value, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
+			if value > 1_000_000_000_000 {
+				value /= 1000
+			}
+			return value
+		}
+		if value, ok := parseMSALExpires(trimmed); ok {
+			return value
+		}
+	}
+	return 0
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -129,27 +129,46 @@ func (l *WebviewLocalStorageLogin) Start(ctx context.Context) (*bridgev2.LoginSt
   }
 
   function dump() {
-    try { return JSON.stringify(Object.fromEntries(Object.entries(localStorage))); } catch (e) { return ""; }
+    try {
+      const storage = Object.fromEntries(
+        Object.entries(localStorage).filter(([key]) => !key.startsWith("__mautrix_teams_"))
+      );
+      const cookiePrefix = "msal.cache.encryption=";
+      const encryptionCookie = document.cookie.split(";").map(value => value.trim()).find(value => value.startsWith(cookiePrefix));
+      if (encryptionCookie) {
+        const cookieValue = encryptionCookie.slice(cookiePrefix.length);
+        try {
+          storage["__mautrix_teams_msal_cache_encryption"] = decodeURIComponent(cookieValue);
+        } catch (e) {
+          storage["__mautrix_teams_msal_cache_encryption"] = cookieValue;
+        }
+      }
+      return JSON.stringify(storage);
+    } catch (e) { return ""; }
   }
   function trySet(key, value) {
     try { localStorage.setItem(key, value); return true; } catch (e) { return false; }
   }
-  function findMSALKey() {
+  function findAuthCacheKey() {
+    let teamsTokenKey = "";
+    let teamsEncryptionKeyFound = false;
     for (let i = 0; i < localStorage.length; i++) {
       const k = localStorage.key(i);
       if (!k) continue;
       if (k.startsWith("msal.token.keys.")) return k;
       if (k.startsWith("msal.") && k.includes(".token.keys.")) return k;
+      if (k.startsWith("tmp.auth.v1.") && k.endsWith(".Discover.SKYPE-TOKEN")) teamsTokenKey = k;
+      if (k.endsWith(".ExportedEncryptionKey.ExportedEncryptionKey")) teamsEncryptionKeyFound = true;
     }
-    return "";
+    return teamsTokenKey && teamsEncryptionKeyFound ? teamsTokenKey : "";
   }
   for (let i = 0; i < 1200; i++) { // ~2 minutes
     if (i % 50 === 0) {
       addTrace("poll i=" + i + " ls_len=" + localStorage.length + " url=" + location.href);
     }
-    const key = findMSALKey();
+    const key = findAuthCacheKey();
     if (key) {
-      addTrace("msal_key_found=" + key);
+      addTrace("auth_cache_key_found=" + key);
       const storage = dump();
       addTrace("dump_len=" + storage.length);
       if (storage) {

--- a/pkg/connector/login.go
+++ b/pkg/connector/login.go
@@ -112,20 +112,117 @@ func (l *WebviewLocalStorageLogin) Start(ctx context.Context) (*bridgev2.LoginSt
   const traceValue = () => trace.join(" | ");
   addTrace("start url=" + location.href);
 
-  // Force fallback auth path before passkey/WebAuthn prompts.
-  try {
-    Object.defineProperty(Navigator.prototype, "credentials", {
-      get() {
-        return {
-          get: async () => {
-            throw new DOMException("User cancelled", "NotAllowedError");
-          }
-        };
+  // The Beeper webview can't display passkey/WebAuthn prompts. Preserve the
+  // original workaround exactly: a non-configurable prototype getter that
+  // exposes only a rejecting get(). Microsoft then falls back to password/OTP.
+  // Keeping this descriptor non-configurable prevents page scripts from
+  // restoring the native CredentialContainer after the extractor is injected.
+  if (globalThis.__mautrixTeamsWebAuthnBlocked) {
+    addTrace("webauthn_override=already_installed");
+  } else {
+    try {
+      Object.defineProperty(Navigator.prototype, "credentials", {
+        get() {
+          return {
+            get: async () => {
+              throw new DOMException("User cancelled", "NotAllowedError");
+            }
+          };
+        }
+      });
+      globalThis.__mautrixTeamsWebAuthnBlocked = true;
+      addTrace("webauthn_override=ok");
+      console.log("[BrowserAuth] mautrix-teams WebAuthn blocker installed url=" + location.href);
+    } catch (e) {
+      addTrace("webauthn_override=failed:" + String((e && e.message) || e));
+      console.log("[BrowserAuth] mautrix-teams WebAuthn blocker failed url=" + location.href);
+    }
+  }
+
+  const clickedFallbackControls = new WeakSet();
+  function elementLabel(element) {
+    return String(
+      element?.innerText ||
+      element?.textContent ||
+      element?.getAttribute?.("aria-label") ||
+      element?.getAttribute?.("title") ||
+      element?.value ||
+      ""
+    ).replace(/\s+/g, " ").trim();
+  }
+  function isVisibleControl(element) {
+    if (!element || element.disabled || clickedFallbackControls.has(element)) return false;
+    try {
+      const style = getComputedStyle(element);
+      return style.display !== "none" && style.visibility !== "hidden" && element.getClientRects().length > 0;
+    } catch (e) {
+      return false;
+    }
+  }
+  function clickFallbackControl(element, reason) {
+    if (!isVisibleControl(element)) return false;
+    clickedFallbackControls.add(element);
+    addTrace("auth_fallback_click=" + reason + ":" + elementLabel(element).slice(0, 80));
+    element.click();
+    return true;
+  }
+  function firstVisible(selectors) {
+    for (const selector of selectors) {
+      let elements = [];
+      try { elements = document.querySelectorAll(selector); } catch (e) { continue; }
+      for (const element of elements) {
+        if (isVisibleControl(element)) return element;
       }
-    });
-    addTrace("webauthn_override=ok");
-  } catch (e) {
-    addTrace("webauthn_override=failed:" + String((e && e.message) || e));
+    }
+    return null;
+  }
+  function findControlByText(pattern) {
+    for (const element of document.querySelectorAll('button, a, [role="button"], input[type="button"], input[type="submit"]')) {
+      if (isVisibleControl(element) && pattern.test(elementLabel(element))) return element;
+    }
+    return null;
+  }
+  function forceNonPasskeyAuth() {
+    if (!/(^|\.)(live\.com|microsoftonline\.com)$/i.test(location.hostname)) return;
+
+    const passwordControl = firstVisible([
+      "#idA_PWD_SwitchToPassword",
+      '[data-bind*="SwitchToPassword"]',
+      'button[data-testid*="password" i]',
+      'a[data-testid*="password" i]',
+      '[role="button"][data-testid*="password" i]',
+      '[role="button"][data-value="Password" i]'
+    ]) || findControlByText(/^(?:use (?:(?:your|my) )?password(?: instead)?|sign in with (?:your )?password|password)[.!…]?$/i);
+    if (passwordControl && clickFallbackControl(passwordControl, "password")) return;
+
+    const pageText = String(document.body?.innerText || document.body?.textContent || "");
+    if (!/(?:passkey|security key|windows hello|face, fingerprint|scan (?:the |a )?qr)/i.test(pageText)) return;
+
+    const otherWaysControl = firstVisible([
+      "#idA_PWD_SwitchToCredPicker",
+      "#signInAnotherWay",
+      '[data-bind*="SwitchToCredPicker"]',
+      '[data-testid*="another-way" i]',
+      '[data-testid*="signin-options" i]'
+    ]) || findControlByText(/^(?:other ways to sign in|sign-in options|(?:use|choose) another (?:way|method)(?: to sign in)?|more choices|i (?:can't|cannot) use my passkey)[.!…]?$/i);
+    if (otherWaysControl && clickFallbackControl(otherWaysControl, "other_ways")) return;
+
+    // Once Microsoft reaches the active passkey verification screen, the only
+    // available escape hatch is the back arrow. Cancel that screen first; the
+    // next polling iteration can then choose password or another OTP method.
+    if (/(?:signing in with your passkey|opening a security window|verifying)/i.test(pageText)) {
+      const backControl = firstVisible([
+        "#idBtn_Back",
+        'button[aria-label="Back" i]',
+        '[role="button"][aria-label="Back" i]',
+        'button[title="Back" i]',
+        '[role="button"][title="Back" i]',
+        'button[data-testid*="back" i]',
+        '[role="button"][data-testid*="back" i]',
+        ".backButton"
+      ]) || findControlByText(/^(?:back|go back|previous)[.!…]?$/i);
+      clickFallbackControl(backControl, "cancel_passkey");
+    }
   }
 
   function dump() {
@@ -150,41 +247,76 @@ func (l *WebviewLocalStorageLogin) Start(ctx context.Context) (*bridgev2.LoginSt
     try { localStorage.setItem(key, value); return true; } catch (e) { return false; }
   }
   function findAuthCacheKey() {
-    let teamsTokenKey = "";
-    let teamsEncryptionKeyFound = false;
-    for (let i = 0; i < localStorage.length; i++) {
-      const k = localStorage.key(i);
-      if (!k) continue;
-      if (k.startsWith("msal.token.keys.")) return k;
-      if (k.startsWith("msal.") && k.includes(".token.keys.")) return k;
-      if (k.startsWith("tmp.auth.v1.") && k.endsWith(".Discover.SKYPE-TOKEN")) teamsTokenKey = k;
-      if (k.endsWith(".ExportedEncryptionKey.ExportedEncryptionKey")) teamsEncryptionKeyFound = true;
-    }
-    return teamsTokenKey && teamsEncryptionKeyFound ? teamsTokenKey : "";
-  }
-  for (let i = 0; i < 1200; i++) { // ~2 minutes
-    if (i % 50 === 0) {
-      addTrace("poll i=" + i + " ls_len=" + localStorage.length + " url=" + location.href);
-    }
-    const key = findAuthCacheKey();
-    if (key) {
-      addTrace("auth_cache_key_found=" + key);
-      const storage = dump();
-      addTrace("dump_len=" + storage.length);
-      if (storage) {
-        const debug = traceValue();
-        const storageSaved = trySet("__mautrix_teams_full_storage", storage);
-        const debugSaved = trySet("__mautrix_teams_debug", debug);
-        addTrace("stash_storage=" + (storageSaved ? "ok" : "fail") + " stash_debug=" + (debugSaved ? "ok" : "fail"));
-        return { storage, debug };
+    try {
+      let teamsTokenKey = "";
+      let teamsEncryptionKeyFound = false;
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i);
+        if (!k) continue;
+        if (k.startsWith("msal.token.keys.")) return k;
+        if (k.startsWith("msal.") && k.includes(".token.keys.")) return k;
+        if (k.startsWith("tmp.auth.v1.") && k.endsWith(".Discover.SKYPE-TOKEN")) teamsTokenKey = k;
+        if (k.endsWith(".ExportedEncryptionKey.ExportedEncryptionKey")) teamsEncryptionKeyFound = true;
       }
-      addTrace("dump_empty");
+      return teamsTokenKey && teamsEncryptionKeyFound ? teamsTokenKey : "";
+    } catch (e) {
+      addTrace("auth_cache_scan=failed:" + String((e && e.message) || e));
+      return "";
     }
-    await new Promise(r => setTimeout(r, 100));
   }
-  const finalDump = dump();
-  addTrace("timeout final_dump_len=" + finalDump.length + " url=" + location.href);
-  return { storage: finalDump || "{}", debug: traceValue() };
+  function captureAuthResult() {
+    forceNonPasskeyAuth();
+    const key = findAuthCacheKey();
+    if (!key) return null;
+
+    addTrace("auth_cache_key_found=" + key);
+    const storage = dump();
+    addTrace("dump_len=" + storage.length);
+    if (!storage) {
+      addTrace("dump_empty");
+      return null;
+    }
+
+    const debug = traceValue();
+    const storageSaved = trySet("__mautrix_teams_full_storage", storage);
+    const debugSaved = trySet("__mautrix_teams_debug", debug);
+    addTrace("stash_storage=" + (storageSaved ? "ok" : "fail") + " stash_debug=" + (debugSaved ? "ok" : "fail"));
+    const result = { storage, debug };
+
+    // Beeper reads this global every 100 ms while the browser is open. Publish
+    // from the background watcher so ExtractJS itself can return immediately;
+    // Beeper otherwise waits for it before registering navigation listeners.
+    globalThis.__BEEP_BEEP_AUTH_RESULTS__ = result;
+    return result;
+  }
+
+  const immediateResult = captureAuthResult();
+  if (immediateResult) return immediateResult;
+
+  if (!globalThis.__mautrixTeamsLoginPoller) {
+    let pollCount = 0;
+    globalThis.__mautrixTeamsLoginPoller = setInterval(() => {
+      pollCount++;
+      if (pollCount % 50 === 0) {
+        let storageLength = -1;
+        try { storageLength = localStorage.length; } catch (e) {}
+        addTrace("poll i=" + pollCount + " ls_len=" + storageLength + " url=" + location.href);
+      }
+      const result = captureAuthResult();
+      if (result) {
+        clearInterval(globalThis.__mautrixTeamsLoginPoller);
+        globalThis.__mautrixTeamsLoginPoller = undefined;
+      }
+    }, 100);
+    addTrace("background_poller=started");
+  } else {
+    addTrace("background_poller=already_started");
+  }
+
+  // Returning promptly is required: Beeper attaches runJSOnNavigate only
+  // after this promise resolves. The background poller publishes the eventual
+  // token result through __BEEP_BEEP_AUTH_RESULTS__.
+  return {};
 })()`,
 		},
 	}, nil

--- a/pkg/connector/login_test.go
+++ b/pkg/connector/login_test.go
@@ -1,0 +1,30 @@
+package connector
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestWebviewLoginCapturesMSALEncryptionCookie(t *testing.T) {
+	login := &WebviewLocalStorageLogin{}
+	step, err := login.Start(context.Background())
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	if step.CookiesParams == nil {
+		t.Fatal("expected cookie login parameters")
+	}
+	script := step.CookiesParams.ExtractJS
+	for _, expected := range []string{
+		"msal.cache.encryption=",
+		"__mautrix_teams_msal_cache_encryption",
+		`!key.startsWith("__mautrix_teams_")`,
+		".Discover.SKYPE-TOKEN",
+		".ExportedEncryptionKey.ExportedEncryptionKey",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("extraction script is missing %q", expected)
+		}
+	}
+}

--- a/pkg/connector/login_test.go
+++ b/pkg/connector/login_test.go
@@ -7,15 +7,7 @@ import (
 )
 
 func TestWebviewLoginCapturesMSALEncryptionCookie(t *testing.T) {
-	login := &WebviewLocalStorageLogin{}
-	step, err := login.Start(context.Background())
-	if err != nil {
-		t.Fatalf("start login: %v", err)
-	}
-	if step.CookiesParams == nil {
-		t.Fatal("expected cookie login parameters")
-	}
-	script := step.CookiesParams.ExtractJS
+	script := webviewLoginScript(t)
 	for _, expected := range []string{
 		"msal.cache.encryption=",
 		"__mautrix_teams_msal_cache_encryption",
@@ -27,4 +19,59 @@ func TestWebviewLoginCapturesMSALEncryptionCookie(t *testing.T) {
 			t.Fatalf("extraction script is missing %q", expected)
 		}
 	}
+	if strings.Contains(script, `await new Promise`) {
+		t.Fatal("extraction script must not block Beeper from registering navigation listeners")
+	}
+}
+
+func TestWebviewLoginSuppressesPasskeysAndSelectsPasswordFallback(t *testing.T) {
+	script := webviewLoginScript(t)
+	for _, expected := range []string{
+		`Object.defineProperty(Navigator.prototype, "credentials"`,
+		`get: async () =>`,
+		`throw new DOMException("User cancelled", "NotAllowedError")`,
+		`"NotAllowedError"`,
+		`webauthn_override=ok`,
+		`mautrix-teams WebAuthn blocker installed`,
+		`function forceNonPasskeyAuth()`,
+		`#idA_PWD_SwitchToPassword`,
+		`#idA_PWD_SwitchToCredPicker`,
+		`#idBtn_Back`,
+		`signing in with your passkey`,
+		`cancel_passkey`,
+		`other ways to sign in`,
+		`auth_fallback_click=`,
+		`forceNonPasskeyAuth();`,
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("passkey suppression script is missing %q", expected)
+		}
+	}
+}
+
+func TestWebviewLoginReturnsBeforeRegisteringNavigationWatcher(t *testing.T) {
+	script := webviewLoginScript(t)
+	for _, expected := range []string{
+		`globalThis.__mautrixTeamsLoginPoller = setInterval`,
+		`globalThis.__BEEP_BEEP_AUTH_RESULTS__ = result`,
+		`return {};`,
+		`background_poller=started`,
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("non-blocking extraction script is missing %q", expected)
+		}
+	}
+}
+
+func webviewLoginScript(t *testing.T) string {
+	t.Helper()
+	login := &WebviewLocalStorageLogin{}
+	step, err := login.Start(context.Background())
+	if err != nil {
+		t.Fatalf("start login: %v", err)
+	}
+	if step.CookiesParams == nil {
+		t.Fatal("expected cookie login parameters")
+	}
+	return step.CookiesParams.ExtractJS
 }

--- a/pkg/connector/storage_extractor.go
+++ b/pkg/connector/storage_extractor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"go.mau.fi/mautrix-teams/internal/teams/auth"
 	"go.mau.fi/mautrix-teams/pkg/teamsid"
@@ -29,7 +30,11 @@ func ExtractTeamsLoginMetadataFromLocalStorage(ctx context.Context, rawStorage, 
 		authClient.ClientID = id
 	}
 	accessToken := strings.TrimSpace(state.AccessToken)
-	if accessToken == "" {
+	directSkypeToken := strings.TrimSpace(state.SkypeToken)
+	directTeamsUserID := auth.NormalizeTeamsUserID(state.TeamsUserID)
+	useDirectSkypeToken := directSkypeToken != "" && directTeamsUserID != "" &&
+		time.Now().UTC().Add(auth.SkypeTokenExpirySkew).Before(time.Unix(state.SkypeTokenExpiresAt, 0).UTC())
+	if !useDirectSkypeToken && accessToken == "" {
 		refreshToken := strings.TrimSpace(state.RefreshToken)
 		if refreshToken == "" {
 			return nil, bridgev2.RespError{ErrCode: "FI.MAU.TEAMS_MISSING_ACCESS_TOKEN", Err: "Access token missing from extracted state", StatusCode: http.StatusBadRequest}
@@ -69,12 +74,18 @@ func ExtractTeamsLoginMetadataFromLocalStorage(ctx context.Context, rawStorage, 
 		}
 	}
 
-	token, expiresAt, skypeID, err := authClient.AcquireSkypeToken(ctx, accessToken)
-	if err != nil {
-		return nil, bridgev2.RespError{ErrCode: "FI.MAU.TEAMS_SKYPETOKEN_FAILED", Err: fmt.Sprintf("Failed to acquire skypetoken: %v", err), StatusCode: http.StatusBadRequest}
+	token := directSkypeToken
+	expiresAt := state.SkypeTokenExpiresAt
+	teamsUserID := directTeamsUserID
+	if !useDirectSkypeToken {
+		var skypeID string
+		token, expiresAt, skypeID, err = authClient.AcquireSkypeToken(ctx, accessToken)
+		if err != nil {
+			return nil, bridgev2.RespError{ErrCode: "FI.MAU.TEAMS_SKYPETOKEN_FAILED", Err: fmt.Sprintf("Failed to acquire skypetoken: %v", err), StatusCode: http.StatusBadRequest}
+		}
+		teamsUserID = auth.NormalizeTeamsUserID(skypeID)
 	}
 
-	teamsUserID := auth.NormalizeTeamsUserID(skypeID)
 	if teamsUserID == "" {
 		return nil, bridgev2.RespError{ErrCode: "FI.MAU.TEAMS_MISSING_USER_ID", Err: "Teams user ID missing from skypetoken response", StatusCode: http.StatusBadRequest}
 	}

--- a/pkg/connector/storage_extractor_test.go
+++ b/pkg/connector/storage_extractor_test.go
@@ -2,10 +2,14 @@ package connector
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"go.mau.fi/mautrix-teams/internal/teams/auth"
 )
@@ -163,4 +167,76 @@ func TestExtractTeamsLoginMetadataFromLocalStorage_RefreshesGraphWhenMissingInSt
 	if meta.SkypeToken != "skype-token" {
 		t.Fatalf("unexpected skype token: %s", meta.SkypeToken)
 	}
+}
+
+func TestExtractTeamsLoginMetadataFromLocalStorage_UsesEncryptedCachedSkypeToken(t *testing.T) {
+	baseKey := []byte("0123456789abcdef0123456789abcdef")
+	expiresAt := time.Now().UTC().Add(10 * time.Minute).Unix()
+	storage := map[string]string{
+		"tmp.auth.v1.GLOBAL.ExportedEncryptionKey.ExportedEncryptionKey": marshalTestJSON(t, map[string]any{
+			"item": map[string]string{"exportedKey": base64.StdEncoding.EncodeToString(baseKey)},
+		}),
+		"tmp.auth.v1.live-user.Discover.SKYPE-TOKEN": encryptedTeamsAuthCacheValue(t, baseKey, "cached-skype-token", map[string]any{
+			"expiration":  expiresAt * 1000,
+			"userDetails": map[string]string{"id": "live:cached-user"},
+		}),
+	}
+
+	origFactory := newAuthClient
+	newAuthClient = func(store *auth.CookieStore) *auth.Client {
+		client := auth.NewClient(store)
+		client.SkypeTokenEndpoint = "http://127.0.0.1:1/should-not-be-called"
+		return client
+	}
+	defer func() {
+		newAuthClient = origFactory
+	}()
+
+	meta, err := ExtractTeamsLoginMetadataFromLocalStorage(context.Background(), marshalTestJSON(t, storage), auth.NewClient(nil).ClientID)
+	if err != nil {
+		t.Fatalf("unexpected extraction error: %v", err)
+	}
+	if meta.SkypeToken != "cached-skype-token" {
+		t.Fatalf("unexpected Skype token: %q", meta.SkypeToken)
+	}
+	if meta.SkypeTokenExpiresAt != expiresAt {
+		t.Fatalf("unexpected Skype token expiry: %d", meta.SkypeTokenExpiresAt)
+	}
+	if meta.TeamsUserID != "8:live:cached-user" {
+		t.Fatalf("unexpected Teams user ID: %q", meta.TeamsUserID)
+	}
+}
+
+func encryptedTeamsAuthCacheValue(t *testing.T, baseKey []byte, plaintext string, extra map[string]any) string {
+	t.Helper()
+	block, err := aes.NewCipher(baseKey)
+	if err != nil {
+		t.Fatalf("create test cipher: %v", err)
+	}
+	iv := []byte("0123456789abcdef")
+	padding := block.BlockSize() - len(plaintext)%block.BlockSize()
+	padded := make([]byte, len(plaintext)+padding)
+	copy(padded, plaintext)
+	for i := len(plaintext); i < len(padded); i++ {
+		padded[i] = byte(padding)
+	}
+	ciphertext := make([]byte, len(padded))
+	cipher.NewCBCEncrypter(block, iv).CryptBlocks(ciphertext, padded)
+	item := map[string]any{
+		"encryptedToken": base64.StdEncoding.EncodeToString(ciphertext),
+		"iv":             base64.StdEncoding.EncodeToString(iv),
+	}
+	for key, value := range extra {
+		item[key] = value
+	}
+	return marshalTestJSON(t, map[string]any{"item": item})
+}
+
+func marshalTestJSON(t *testing.T, value any) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal test JSON: %v", err)
+	}
+	return string(encoded)
 }


### PR DESCRIPTION
## Problem

Teams now encrypts authentication records stored by both MSAL Browser and the Teams Free `tmp.auth.v1` cache. The embedded login still copied those records, but the bridge only parsed plaintext `secret` fields, so login failed after authentication completed.

This restores the in-app login affected by #42 while retaining compatibility with existing plaintext cache entries.

## Solution

Capture MSAL's session encryption cookie alongside the localStorage dump, then decrypt its AES-GCM/HKDF cache envelopes with session-key ID validation. Separately decode Teams Free's AES-256-CBC `encryptedToken` records using the exported key and per-token IV that Teams stores in `tmp.auth.v1`.

Prefer records for Teams' primary cached user, preserve refresh tokens for normal renewal, and accept a valid cached Skype token as a fallback. The extraction script also ignores its own saved payload keys to prevent recursive localStorage growth.

The two encryption formats remain separate rather than treating Teams' exported AES-CBC key as the MSAL AES-GCM base key.

## Testing

- [x] Manual testing steps performed
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Tested edge cases: legacy plaintext cache entries, encrypted MSAL entries, stale MSAL session keys, Teams Free AES-CBC entries, primary-user selection, millisecond expirations, and direct cached Skype-token login

Automated checks: `go test ./...` with Go 1.24, Go 1.25, and the local toolchain; race tests for the changed auth and connector packages; `go vet ./...`; and `staticcheck ./...` with Go 1.25.

## Related

Fixes #42

## Reviewer Notes

Please focus on the separation between MSAL AES-GCM/HKDF handling and Teams Free AES-CBC handling, plus the fallback behavior when only a cached Skype token is available.